### PR TITLE
Buffersupport

### DIFF
--- a/lib/nodesol.js
+++ b/lib/nodesol.js
@@ -210,7 +210,7 @@ var NodeSol = Class.extend({
             callback = function() {};
         }
 
-        if (typeof(message) !== 'string') {
+        if (typeof(message) !== 'string' && !Buffer.isBuffer(message)) {
             message = JSON.stringify(message);
         }
 

--- a/lib/nodesol.js
+++ b/lib/nodesol.js
@@ -2,7 +2,8 @@ var kafka = require('prozess'),
     async = require('async'),
     CBuffer = require('CBuffer'),
     Class = require('uberclass'),
-    os = require('os');
+    os = require('os'),
+    Buffer = require('buffer').Buffer;
 
 var QueueProducer = Class.extend({
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "mocha": "*",
     "should": "*",
     "sandboxed-module": "*",
-    "jshint": "*"
+    "jshint": "*",
+    "buffertools": "*"
   },
   "scripts": {
     "test": "mocha -R nyan tests",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "uber-nodesol-write",
   "description": "Kafka producer.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "contributors": [
     "Raynos <raynos2@gmail.com>"
   ],

--- a/tests/test_nodesol.js
+++ b/tests/test_nodesol.js
@@ -4,6 +4,7 @@ var mock = require('nodemock');
 var async = require('async');
 var SandboxedModule = require('sandboxed-module');
 var EventEmitter = require('events').EventEmitter;
+var buffertools = require('buffertools');
 
 
 describe('NodeSol', function() {
@@ -119,6 +120,16 @@ describe('NodeSol', function() {
                 process.nextTick(function() {
                     should.not.exist(err);
                     kafka_mock.messages[0].should.equal("{\"ts\":1369945301.743,\"host\":\"test_host\",\"msg\":\"test_message\"}", function() {});
+                    done();
+                });
+            });
+        });
+        it('should log a byte buffer to specified topic', function(done) {
+            var buf = new Buffer([0x3, 0x4, 0x23, 0x42]);
+            ns.produce('test_buffer', buf, function(err) {
+                process.nextTick(function() {
+                    should.not.exist(err);
+                    assert(buffertools.compare(kafka_mock.messages[0], buf)===0);
                     done();
                 });
             });


### PR DESCRIPTION
Nodesol Today forces all messages to be either String or Objects. However, for Heatpipe we need to be able to write encoded bytes into Kafka, thus the need to support Buffer as input. 

This changelist adds that support  and also bumps up version of nodesol to 1.0.1
