### PR TITLE
Add destroy() method

### DIFF
--- a/lib/nodesol.js
+++ b/lib/nodesol.js
@@ -11,6 +11,7 @@ var QueueProducer = Class.extend({
     RECONNECT_SCHEDULED: 1,
     CONNECTING: 2,
     CONNECTED: 3,
+    DESTROYED: 4,
 
     init: function(topic, broker_host, broker_port, options) {
         var self = this;
@@ -37,6 +38,9 @@ var QueueProducer = Class.extend({
 
     schedule_reconnect: function() {
         var self = this;
+        if (self.state === self.DESTROYED) {
+            return;
+        }
         if (self.state === self.DISCONNECTED) {
             self.state = self.RECONNECT_SCHEDULED;
             setTimeout(function() {
@@ -45,15 +49,25 @@ var QueueProducer = Class.extend({
         }
     },
 
+    destroy: function() {
+        var self = this;
+        self.state = self.DESTROYED;
+        self.cleanup();
+    },
+
+    cleanup: function() {
+        var self = this;
+        // clean up previous connection if any
+        if (self.connection && self.connection.connection && self.connection.connection.destroy) {
+            self.connection.connection.destroy();
+        }
+    },
+
     connect: function(callback) {
         var self = this;
 
         callback = callback || function() {};
 
-        // clean up previous connection if any
-        if (self.connection && self.connection.connection && self.connection.connection.destroy) {
-            self.connection.connection.destroy();
-        }
 
         self.connection = new kafka.Producer(self.topic, {
             host: self.broker_host,
@@ -168,7 +182,7 @@ var NodeSol = Class.extend({
         if (!callback) {
             callback = function() {};
         }
-      
+
         callback();
     },
 
@@ -182,7 +196,7 @@ var NodeSol = Class.extend({
             var producer = new QueueProducer(
                 topic,
                 self.leafHost,
-                self.leafPort, 
+                self.leafPort,
                 {
                     reconnect_after: self.broker_reconnect_after,
                     queue_limit: self.queue_limit,

--- a/lib/nodesol.js
+++ b/lib/nodesol.js
@@ -68,6 +68,7 @@ var QueueProducer = Class.extend({
 
         callback = callback || function() {};
 
+        self.cleanup();
 
         self.connection = new kafka.Producer(self.topic, {
             host: self.broker_host,


### PR DESCRIPTION
Allow to explicitly `destory()` the producer, which forces the reconnection attempts to cease.

cc @Raynos 
